### PR TITLE
fixes for ios11

### DIFF
--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectTasksOptions" suppressed-tasks="Babel" />
+</project>

--- a/examples/ar_examples.html
+++ b/examples/ar_examples.html
@@ -27,7 +27,7 @@
 
 		<script src="three.min.js"></script>
 		<script src="TeapotBufferGeometry.js"></script>
-		<script type="module" src="../polyfill/XRPolyfill.js"></script>
+		<script type="module" src="./polyfill/XRPolyfill.js"></script>
 		<script src="common_examples.js"></script>
 		<script src="ar_examples.js"></script>
 	</head>

--- a/examples/common_examples.js
+++ b/examples/common_examples.js
@@ -99,7 +99,6 @@ class XRExampleBase {
 		this.renderer.setSize(width, height)
 		this.session.baseLayer.appendChild(this.renderer.domElement)
 		this.renderer.domElement.style.position = 'absolute'
-		// this.el.style.position = 'relative';
 
 
 		if(this.createVirtualReality){

--- a/examples/common_examples.js
+++ b/examples/common_examples.js
@@ -98,6 +98,9 @@ class XRExampleBase {
 		this.camera.updateProjectionMatrix()
 		this.renderer.setSize(width, height)
 		this.el.appendChild(this.renderer.domElement)
+		this.renderer.domElement.style.position = 'absolute'
+		this.el.style.position = 'relative';
+
 
 		if(this.createVirtualReality){
 			const reality = this.session.createVirtualReality('VR Example', false)

--- a/examples/common_examples.js
+++ b/examples/common_examples.js
@@ -97,7 +97,6 @@ class XRExampleBase {
 		this.camera.aspect = width / height
 		this.camera.updateProjectionMatrix()
 		this.renderer.setSize(width, height)
-		this.session.baseLayer.appendChild(this.renderer.domElement)
 		this.renderer.domElement.style.position = 'absolute'
 
 

--- a/examples/dist/webxr-polyfill.js
+++ b/examples/dist/webxr-polyfill.js
@@ -3014,6 +3014,7 @@ var CameraReality = function (_Reality) {
 					}).then(function (stream) {
 						_this2._el = document.createElement('video');
 						_this2._el.setAttribute('class', 'camera-reality-video');
+						_this2._el.setAttribute('playsinline', true);
 						_this2._el.style.position = 'absolute';
 						_this2._el.style.width = '100%';
 						_this2._el.style.height = '100vh';

--- a/examples/polyfill/reality/CameraReality.js
+++ b/examples/polyfill/reality/CameraReality.js
@@ -47,6 +47,7 @@ export default class CameraReality extends Reality {
 				}).then(stream => {
 					this._el = document.createElement('video')
 					this._el.setAttribute('class', 'camera-reality-video')
+                    this._el.setAttribute('playsinline', true);
 					this._el.style.position = 'absolute'
 					this._el.style.width = '100%'
 					this._el.style.height = '100vh'

--- a/examples/polyfill/reality/CameraReality.js
+++ b/examples/polyfill/reality/CameraReality.js
@@ -50,9 +50,9 @@ export default class CameraReality extends Reality {
 					this._videoEl.setAttribute('playsinline', true);
 					this._videoEl.style.position = 'absolute'
 					this._videoEl.style.width = '100%'
-					this._videoEl.style.height = '100vh'
+					this._videoEl.style.height = '100%'
 					this._videoEl.srcObject = stream
-					document.body.prepend(this._videoEl)
+					document.getElementById("target").prepend(this._videoEl)
 					this._videoEl.play()
 				}).catch(err => {
 					console.error('Could not set up video stream', err)

--- a/examples/polyfill/reality/CameraReality.js
+++ b/examples/polyfill/reality/CameraReality.js
@@ -47,6 +47,7 @@ export default class CameraReality extends Reality {
 				}).then(stream => {
 					this._videoEl = document.createElement('video')
 					this._videoEl.setAttribute('class', 'camera-reality-video')
+					this._videoEl.setAttribute('playsinline', true);
 					this._videoEl.style.position = 'absolute'
 					this._videoEl.style.width = '100%'
 					this._videoEl.style.height = '100vh'


### PR DESCRIPTION
This fixes the video missing on ios11 and moves the camera to be properly below the threejs view. Also fixes the path in ar_examples.html